### PR TITLE
Added `null` as a valid value for RequestOptions.encoding

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -231,7 +231,7 @@ export interface RequestOptions {
     followRedirect?: boolean|((response: http.IncomingMessage) => boolean);
     followAllRedirects?: boolean;
     maxRedirects?: number;
-    encoding?: string;
+    encoding?: string | null;
     pool?: any;
     timeout?: number;
     proxy?: any;


### PR DESCRIPTION
Current "master" fails if `encoding: null` compiling with TS2.0 with --strictNullChecks (`?` optional allows only `undefined`, not `null`).

When `encoding` is `null`, request returns a binary response (content is a `Buffer`): marking the field only as optional with `?` allows `undefined` - which means `utf8` - but not for `null` (explained in https://github.com/request/request/blob/master/README.md#requestoptions-callback look for `encoding`).
