### PR TITLE
Target es5 for better compatibily

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "preserveConstEnums": false,
     "sourceMap": true,
     "declaration": true,
-    "target": "es6"
+    "target": "es5",
+    "lib": ["es6", "es2015"]
   },
   "files": [
     "typings/tsd.d.ts",


### PR DESCRIPTION
Hi,
Thanks for your work on web-request, I find it very modern and easy to use.
I had a problem to use it in a react application. I used [create-react-app-ts](https://github.com/wmonk/create-react-app-typescript) to create my react application using typescript. This help to deal with project configuration and build. Thing is, it only supports es5 and considers that build your project for es6 is a bad practice for now [source](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify).
So I was not able to build my project with web-request as dependency. 

I think it will bring more user to have a plugin directly compatible with es5 on npm. Here are the changes.